### PR TITLE
Fetch and render two-level menu data

### DIFF
--- a/package/src/app/layouts/full/full.component.ts
+++ b/package/src/app/layouts/full/full.component.ts
@@ -15,7 +15,8 @@ import { TablerIconsModule } from 'angular-tabler-icons';
 import { HeaderComponent } from './header/header.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { AppNavItemComponent } from './sidebar/nav-item/nav-item.component';
-import { navItems } from './sidebar/sidebar-data';
+import { NavItem } from './sidebar/nav-item/nav-item';
+import { MenuService } from 'src/app/services/menu.service';
 import { AppTopstripComponent } from './top-strip/topstrip.component';
 
 
@@ -41,7 +42,7 @@ const TABLET_VIEW = 'screen and (min-width: 769px) and (max-width: 1024px)';
   encapsulation: ViewEncapsulation.None
 })
 export class FullComponent implements OnInit {
-  navItems = navItems;
+  navItems: NavItem[] = [];
 
   @ViewChild('leftsidenav')
   public sidenav: MatSidenav;
@@ -64,6 +65,7 @@ export class FullComponent implements OnInit {
     private settings: CoreService,
     private router: Router,
     private breakpointObserver: BreakpointObserver,
+    private menuService: MenuService,
   ) {
     this.htmlElement = document.querySelector('html')!;
     this.layoutChangesSubscription = this.breakpointObserver
@@ -88,7 +90,15 @@ export class FullComponent implements OnInit {
       });
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {
+    this.menuService.list().subscribe((items) => {
+      // Support {items: [...] } mock
+      const normalized = Array.isArray((items as unknown as any).items)
+        ? ((items as unknown as any).items as NavItem[])
+        : (items as NavItem[]);
+      this.navItems = normalized;
+    });
+  }
 
   ngOnDestroy() {
     this.layoutChangesSubscription.unsubscribe();

--- a/package/src/app/services/menu.service.ts
+++ b/package/src/app/services/menu.service.ts
@@ -1,0 +1,31 @@
+import { inject, Injectable, InjectionToken } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, of } from 'rxjs';
+import { NavItem } from '../layouts/full/sidebar/nav-item/nav-item';
+
+export interface MenuSectionResponse {
+  items: NavItem[];
+}
+
+export const MENU_API_BASE_URL = new InjectionToken<string>('MENU_API_BASE_URL');
+
+@Injectable({ providedIn: 'root' })
+export class MenuService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = inject(MENU_API_BASE_URL, { optional: true }) ?? '/api';
+
+  /**
+   * Fetch two-level menu items for the left sidebar. Falls back to local mock when API fails.
+   */
+  list(): Observable<NavItem[]> {
+    const url = `${this.baseUrl}/menu`;
+    return this.http.get<MenuSectionResponse | NavItem[]>(url).pipe(
+      // Support both { items: [...] } and [...] payloads
+      catchError(() => this.http.get<MenuSectionResponse | NavItem[]>(`/assets/mock/menu.json`)),
+      // Normalize to NavItem[] and swallow errors with empty array
+      // eslint-disable-next-line rxjs/no-ignored-error
+      catchError(() => of([] as NavItem[]))
+    ) as unknown as Observable<NavItem[]>;
+  }
+}
+

--- a/package/src/assets/mock/menu.json
+++ b/package/src/assets/mock/menu.json
@@ -1,0 +1,28 @@
+{
+  "items": [
+    {
+      "displayName": "Analytics",
+      "iconName": "chart-bar",
+      "children": [
+        { "displayName": "Summary", "iconName": "layout-grid-add", "route": "/analytics/summary" },
+        { "displayName": "Files", "iconName": "file", "route": "/analytics/files" },
+        { "displayName": "Scan Incidents", "iconName": "alert-triangle", "route": "/analytics/incidents" },
+        { "displayName": "Queries", "iconName": "search", "route": "/analytics/queries" }
+      ]
+    },
+    {
+      "displayName": "Discovery",
+      "iconName": "compass",
+      "children": [
+        { "displayName": "Storages", "iconName": "database", "route": "/discovery/storages" },
+        { "displayName": "Identities", "iconName": "users", "route": "/discovery/identities" },
+        { "displayName": "Data Types", "iconName": "category", "route": "/discovery/data-types" },
+        { "displayName": "Logs & Reports", "iconName": "report", "route": "/discovery/logs-reports" },
+        { "displayName": "Fabric", "iconName": "settings", "route": "/discovery/fabric" },
+        { "displayName": "System", "iconName": "device-desktop", "route": "/discovery/system" },
+        { "displayName": "Notifications", "iconName": "bell", "route": "/discovery/notifications" }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
Implement API-driven two-level left sidebar menu with local mock fallback.

The left sidebar menu now fetches its data from `/api/menu`, supporting a two-level hierarchy. A local mock (`/assets/mock/menu.json`) is provided as a fallback if the API is unreachable, ensuring continued development and functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-f049208b-91c7-459f-8174-fe19b6613a30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f049208b-91c7-459f-8174-fe19b6613a30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

