### PR TITLE
Fix left menu expand icon and associations

### DIFF
--- a/package/src/app/layouts/full/sidebar/nav-item/nav-item.component.html
+++ b/package/src/app/layouts/full/sidebar/nav-item/nav-item.component.html
@@ -19,7 +19,7 @@
         <span class="{{ item.chipClass }} p-x-8 p-y-4 item-chip f-w-500 rounded-pill ">{{ item.chipContent }}</span>
       </span>
       }
-    <mat-icon [@indicatorRotate]="expanded ? 'expanded' : 'collapsed'">
+    <mat-icon [ngClass]="{ rotated: expanded }">
       expand_more
     </mat-icon>
   </span>

--- a/package/src/app/layouts/full/sidebar/nav-item/nav-item.component.ts
+++ b/package/src/app/layouts/full/sidebar/nav-item/nav-item.component.ts
@@ -36,7 +36,7 @@ export class AppNavItemComponent implements OnChanges {
   ngOnChanges() {
     const url = this.navService.currentUrl();
     if (this.item.route && url) {
-      this.expanded = url.indexOf(`/${this.item.route}`) === 0;
+      this.expanded = url.indexOf(this.item.route) === 0;
       this.ariaExpanded = this.expanded;
     }
   }

--- a/package/src/app/layouts/full/sidebar/sidebar.component.html
+++ b/package/src/app/layouts/full/sidebar/sidebar.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center justify-content-between">
-  <div class="user-profile profile-bar w-100" style="background: url(assets/images/backgrounds/user-info.jpg) no-repeat">
+  <div class="user-profile profile-bar w-100" style="background: url(/assets/images/backgrounds/user-info.jpg) no-repeat">
     <!-- User profile image -->
     <div class="profile-img">
       <img src="/assets/images/profile/user-1.jpg" alt="user" width="50" class="rounded-circle" />

--- a/package/src/app/pages/pages.routes.ts
+++ b/package/src/app/pages/pages.routes.ts
@@ -7,10 +7,7 @@ export const PagesRoutes: Routes = [
     component: StarterComponent,
     data: {
       title: 'Starter Page',
-      urls: [
-        { title: 'Dashboard', url: '/dashboards/dashboard1' },
-        { title: 'Starter Page' },
-      ],
+      urls: [{ title: 'Dashboard', url: '/dashboard' }, { title: 'Starter Page' }],
     },
   },
   {

--- a/package/src/assets/mock/menu.json
+++ b/package/src/assets/mock/menu.json
@@ -1,6 +1,6 @@
 {
   "items": [
-    { "displayName": "Dashboard", "iconName": "dashboard", "route": "/discovery/storages" },
+    { "displayName": "Dashboard", "iconName": "dashboard", "route": "/dashboard" },
     {
       "displayName": "Analytics",
       "iconName": "chart-bar",
@@ -21,7 +21,7 @@
       ]
     },
     { "displayName": "Storages", "iconName": "database", "route": "/discovery/storages" },
-    { "displayName": "Data Classifiers", "iconName": "database", "route": "/Data/Classifiers" },
+    { "displayName": "Data Classifiers", "iconName": "database", "route": "/dashboard/data-classifiers" },
     { "displayName": "Identities", "iconName": "users", "route": "/discovery/identities" },
     { "displayName": "Data Types", "iconName": "category", "route": "/discovery/data-types" },
     { "displayName": "Logs & Reports", "iconName": "report", "route": "/discovery/logs-reports" },

--- a/package/src/assets/scss/layouts/_sidebar.scss
+++ b/package/src/assets/scss/layouts/_sidebar.scss
@@ -164,6 +164,10 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            transition: transform 200ms ease-in-out;
+            &.rotated {
+              transform: rotate(180deg);
+            }
           }
         }
       }


### PR DESCRIPTION
Fix left menu expand icon rotation and link 'Data Classifiers' and 'Dashboard' to their correct routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9506a47-9e99-407b-8601-cc3fddd8364f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9506a47-9e99-407b-8601-cc3fddd8364f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

